### PR TITLE
Add FastAPI backend and Next.js frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,6 +168,8 @@ config.ini
 cookies/
 cookies.json
 *.json
+!frontend/package.json
+!frontend/tsconfig.json
 
 # Log files
 *.log
@@ -206,3 +208,6 @@ desktop.ini
 .env.development.local
 .env.test.local
 .env.production.local
+# Node
+frontend/node_modules/
+frontend/.next/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# X Scraper Full-Stack App
+
+This project contains a FastAPI backend and Next.js frontend for scraping X (Twitter) using your own credentials.
+
+## Getting Started
+
+### Backend
+
+```bash
+pip install -r requirements.txt
+uvicorn backend.main:app --reload
+```
+
+### Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The frontend expects the backend to run on `http://localhost:8000`.

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+# Backend package

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,0 +1,55 @@
+from datetime import datetime, timedelta
+from typing import Optional
+
+from jose import jwt, JWTError
+from passlib.context import CryptContext
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from sqlalchemy.orm import Session
+
+from . import models
+from .database import get_db
+
+SECRET_KEY = "CHANGE_ME"
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+
+def get_current_user(db: Session = Depends(get_db), token: str = Depends(oauth2_scheme)) -> models.User:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str | None = payload.get("sub")
+        if username is None:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+
+    user = db.query(models.User).filter(models.User.username == username).first()
+    if user is None:
+        raise credentials_exception
+    return user

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,19 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./app.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+
+from .database import Base, engine
+from .routers import auth_routes, scrape_routes
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="X Scraper API")
+
+app.include_router(auth_routes.router)
+app.include_router(scrape_routes.router)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,10 @@
+from sqlalchemy import Column, Integer, String
+from .database import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, index=True)
+    hashed_password = Column(String)

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -1,0 +1,1 @@
+# Routers package

--- a/backend/routers/auth_routes.py
+++ b/backend/routers/auth_routes.py
@@ -1,0 +1,35 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .. import models, schemas, auth
+from ..database import get_db
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post("/signup", response_model=schemas.Token)
+def signup(user: schemas.UserCreate, db: Session = Depends(get_db)):
+    existing = db.query(models.User).filter(models.User.username == user.username).first()
+    if existing:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Username already registered")
+
+    user_obj = models.User(
+        username=user.username,
+        hashed_password=auth.get_password_hash(user.password),
+    )
+    db.add(user_obj)
+    db.commit()
+    db.refresh(user_obj)
+
+    token = auth.create_access_token({"sub": user.username})
+    return {"access_token": token}
+
+
+@router.post("/login", response_model=schemas.Token)
+def login(form_data: schemas.UserLogin, db: Session = Depends(get_db)):
+    user_obj = db.query(models.User).filter(models.User.username == form_data.username).first()
+    if not user_obj or not auth.verify_password(form_data.password, user_obj.hashed_password):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Incorrect username or password")
+
+    token = auth.create_access_token({"sub": user_obj.username})
+    return {"access_token": token}

--- a/backend/routers/scrape_routes.py
+++ b/backend/routers/scrape_routes.py
@@ -1,0 +1,53 @@
+import asyncio
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from .. import schemas, auth
+from ..database import get_db
+from ..auth import get_current_user
+
+from config import TwitterCredentials, TwitterConfig, SearchParameters, SearchMode
+from scraper import TwitterScraper
+from data_utils import TweetDataExtractor
+
+router = APIRouter(prefix="/scrape", tags=["scrape"])
+
+
+@router.post("/tweets", response_model=schemas.ScrapeResponse)
+async def scrape_tweets(request: schemas.ScrapeRequest, current_user=Depends(get_current_user), db: Session = Depends(get_db)):
+    credentials = TwitterCredentials(
+        auth_id=request.x_auth_id,
+        password=request.x_password,
+        cookies_file=f"cookies/{request.x_auth_id}.json"
+    )
+    config = TwitterConfig(credentials=credentials)
+    scraper = TwitterScraper(config)
+
+    try:
+        await scraper.authenticate()
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    if request.mode == "timeline":
+        if not request.screen_name:
+            raise HTTPException(status_code=400, detail="screen_name required")
+        tweets = await scraper.fetch_user_timeline(request.screen_name, count=request.count)
+    else:
+        if not request.query:
+            raise HTTPException(status_code=400, detail="query required")
+        mode_map = {
+            "date_range": SearchMode.DATE_RANGE,
+            "popular": SearchMode.POPULAR,
+            "latest": SearchMode.LATEST,
+        }
+        search_params = SearchParameters(
+            query=request.query,
+            count=request.count,
+            mode=mode_map[request.mode],
+            start_date=request.start_date,
+            end_date=request.end_date,
+        )
+        tweets = await scraper.search_tweets(search_params)
+
+    data = TweetDataExtractor.extract_tweet_data(tweets)
+    return {"tweets": data}

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,0 +1,32 @@
+from pydantic import BaseModel
+from typing import Optional, Literal, List, Dict
+
+
+class UserCreate(BaseModel):
+    username: str
+    password: str
+
+
+class UserLogin(BaseModel):
+    username: str
+    password: str
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class ScrapeRequest(BaseModel):
+    x_auth_id: str
+    x_password: str
+    mode: Literal["timeline", "date_range", "popular", "latest"] = "timeline"
+    screen_name: Optional[str]
+    query: Optional[str]
+    count: int = 50
+    start_date: Optional[str]
+    end_date: Optional[str]
+
+
+class ScrapeResponse(BaseModel):
+    tweets: List[Dict]

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,5 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+module.exports = nextConfig

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "scraper-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tailwindcss": "^3.3.0",
+    "autoprefixer": "^10.4.2",
+    "postcss": "^8.4.14"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "@types/react": "^18.0.0",
+    "@types/node": "^20.0.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,0 +1,7 @@
+export default function Footer() {
+  return (
+    <footer className="text-center p-4 text-sm text-gray-500">
+      © 2025 X Scraper
+    </footer>
+  )
+}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function Navbar() {
+  return (
+    <nav className="bg-gray-800 text-white p-4 flex justify-between">
+      <div className="font-bold">X Scraper</div>
+      <div className="space-x-4">
+        <Link href="/dashboard" className="hover:underline">Dashboard</Link>
+        <Link href="/login" className="hover:underline">Login</Link>
+        <Link href="/signup" className="hover:underline">Sign Up</Link>
+      </div>
+    </nav>
+  )
+}

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app'
+import '../styles/globals.css'
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />
+}

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react'
+import Navbar from '../components/Navbar'
+import Footer from '../components/Footer'
+
+export default function Dashboard() {
+  const [mode, setMode] = useState('timeline')
+  const [authId, setAuthId] = useState('')
+  const [authPass, setAuthPass] = useState('')
+  const [screenName, setScreenName] = useState('')
+  const [query, setQuery] = useState('')
+  const [count, setCount] = useState(50)
+  const [result, setResult] = useState<any[]>([])
+  const [loading, setLoading] = useState(false)
+
+  const scrape = async () => {
+    setLoading(true)
+    const token = localStorage.getItem('token') || ''
+    const payload: any = { x_auth_id: authId, x_password: authPass, mode, count }
+    if (mode === 'timeline') payload.screen_name = screenName
+    else payload.query = query
+
+    const res = await fetch('http://localhost:8000/scrape/tweets', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify(payload)
+    })
+    setLoading(false)
+    if (res.ok) {
+      const data = await res.json()
+      setResult(data.tweets)
+    } else {
+      alert('Scrape failed')
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <main className="flex-grow p-4 space-y-4">
+        <div className="space-x-2">
+          <input value={authId} onChange={e => setAuthId(e.target.value)} placeholder="X Auth ID" className="border p-2" />
+          <input type="password" value={authPass} onChange={e => setAuthPass(e.target.value)} placeholder="X Password" className="border p-2" />
+          <select value={mode} onChange={e => setMode(e.target.value)} className="border p-2">
+            <option value="timeline">Timeline</option>
+            <option value="popular">Popular</option>
+            <option value="latest">Latest</option>
+          </select>
+          {mode === 'timeline' ? (
+            <input value={screenName} onChange={e => setScreenName(e.target.value)} placeholder="Screen Name" className="border p-2" />
+          ) : (
+            <input value={query} onChange={e => setQuery(e.target.value)} placeholder="Query" className="border p-2" />
+          )}
+          <input type="number" value={count} onChange={e => setCount(parseInt(e.target.value))} className="border p-2 w-24" />
+          <button onClick={scrape} className="bg-blue-600 text-white px-4 py-2" disabled={loading}>{loading ? 'Loading...' : 'Scrape'}</button>
+        </div>
+        <pre className="bg-gray-100 p-2 overflow-auto text-sm max-h-96">{JSON.stringify(result, null, 2)}</pre>
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,0 +1,16 @@
+import Navbar from '../components/Navbar'
+import Footer from '../components/Footer'
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <main className="flex-grow flex items-center justify-center flex-col space-y-4">
+        <h1 className="text-3xl font-bold">Welcome to X Scraper</h1>
+        <Link href="/login" className="bg-blue-600 text-white px-4 py-2 rounded">Get Started</Link>
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+import Navbar from '../components/Navbar'
+import Footer from '../components/Footer'
+
+export default function Login() {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [loading, setLoading] = useState(false)
+  const router = useRouter()
+
+  const handleLogin = async () => {
+    setLoading(true)
+    const res = await fetch('http://localhost:8000/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    })
+    setLoading(false)
+    if (res.ok) {
+      const data = await res.json()
+      localStorage.setItem('token', data.access_token)
+      router.push('/dashboard')
+    } else {
+      alert('Login failed')
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <main className="flex-grow flex items-center justify-center">
+        <div className="w-full max-w-md space-y-4 p-6 bg-white rounded shadow">
+          <h2 className="text-2xl font-bold text-center">Login</h2>
+          <input className="w-full border p-2" placeholder="Username" value={username} onChange={e => setUsername(e.target.value)} />
+          <input className="w-full border p-2" type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
+          <button onClick={handleLogin} className="w-full bg-blue-600 text-white py-2" disabled={loading}>{loading ? 'Loading...' : 'Login'}</button>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/frontend/src/pages/signup.tsx
+++ b/frontend/src/pages/signup.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+import Navbar from '../components/Navbar'
+import Footer from '../components/Footer'
+
+export default function Signup() {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [loading, setLoading] = useState(false)
+  const router = useRouter()
+
+  const handleSignup = async () => {
+    setLoading(true)
+    const res = await fetch('http://localhost:8000/auth/signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    })
+    setLoading(false)
+    if (res.ok) {
+      router.push('/login')
+    } else {
+      alert('Signup failed')
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <main className="flex-grow flex items-center justify-center">
+        <div className="w-full max-w-md space-y-4 p-6 bg-white rounded shadow">
+          <h2 className="text-2xl font-bold text-center">Sign Up</h2>
+          <input className="w-full border p-2" placeholder="Username" value={username} onChange={e => setUsername(e.target.value)} />
+          <input className="w-full border p-2" type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
+          <button onClick={handleSignup} className="w-full bg-blue-600 text-white py-2" disabled={loading}>{loading ? 'Loading...' : 'Sign Up'}</button>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    "./src/pages/**/*.{js,ts,jsx,tsx}",
+    "./src/components/**/*.{js,ts,jsx,tsx}"
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,9 @@ twikit>=1.0.0
 pandas>=1.5.0
 asyncio
 nest-asyncio
-openpyxl
+openpyxlfastapi
+uvicorn[standard]
+sqlalchemy
+passlib[bcrypt]
+python-multipart
+python-jose


### PR DESCRIPTION
## Summary
- introduce FastAPI backend with user auth and tweet scraping endpoints
- add Next.js frontend with Tailwind for login, signup, and dashboard
- update requirements and ignore node artifacts
- provide README instructions

## Testing
- `python -m py_compile backend/*.py backend/routers/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68629652c7488321b8106b5ea18fd87f